### PR TITLE
Adds Docker.start, Docker.stop and Docker.wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@
 
 ## Usage
 
+Use it in a with statement:
 ```python
 with Docker() as docker:
     docker.run('command')
+```
+
+or as a decorator:
+```python
+    @Docker.wrap()
+    def run_command_in_container(command, docker)
+        docker.run(command)
 ```
 
 Read the documentation on [docker-wrapper-py.readthedocs.org](http://docker-wrapper-py.readthedocs.org)

--- a/docker/errors.py
+++ b/docker/errors.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+
+class DockerUnavailableError(Exception):
+
+    def __init__(self, message=None):
+        super(DockerUnavailableError, self).__init__(message or 'Docker is not available')

--- a/docker/manager.py
+++ b/docker/manager.py
@@ -22,7 +22,6 @@ def _execute(cmd):
     result.err = stderr.decode('utf-8').strip() if stderr else ''
     result.return_code = process.returncode
     result.succeeded = result.return_code == 0
-
     return result
 
 
@@ -118,6 +117,25 @@ class Docker(object):
         _execute('docker kill {0}'.format(self.container_name))
         _execute('docker rm {0}'.format(self.container_name))
         return self
+
+    @staticmethod
+    def wrap(*wrap_args, **wrap_kwargs):
+        """
+        Decorator that wraps the function call in a Docker with statement. It
+        accepts the same arguments. This decorator adds a docker manager instance
+        to the kwargs passed into the decorated function.
+
+        :return: The decorated function.
+        """
+        def activate(func):
+            def wrapper(*args, **kwargs):
+                with Docker(*wrap_args, **wrap_kwargs) as docker:
+                    kwargs['docker'] = docker
+                    return func(*args, **kwargs)
+
+            return wrapper
+
+        return activate
 
     @staticmethod
     def _get_working_directory(working_directory):

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -13,7 +13,16 @@ Install docker-wrapper with pip:
 Usage
 ~~~~~
 
+Use it in a with statement:
+
 .. code-block:: python
 
     with Docker() as docker:
         docker.run('command')
+
+or as a decorator:
+.. code-block:: python
+
+    @Docker.wrap()
+    def run_command_in_container(command, docker)
+        docker.run(command)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,10 +1,15 @@
 import unittest
 from random import randint
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from docker.manager import Docker
 
 
 class DockerBasicInteractionTests(unittest.TestCase):
+
     def test_create_files(self):
         with Docker() as docker:
             docker.run("touch file1")
@@ -49,3 +54,12 @@ class DockerBasicInteractionTests(unittest.TestCase):
     def test__get_working_directory(self):
         self.assertEqual(Docker._get_working_directory('directory'), '~/directory')
         self.assertEqual(Docker._get_working_directory('/absolute/path'), '/absolute/path')
+
+    @mock.patch('docker.manager.Docker.stop')
+    @mock.patch('docker.manager.Docker.start')
+    def test_with_statement(self, mock_start, mock_stop):
+        with Docker() as docker:
+            self.assertIsInstance(docker, Docker)
+
+        mock_start.assert_called_once_with()
+        mock_stop.assert_called_once_with()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,11 +1,12 @@
 import unittest
 from random import randint
+
+from docker.manager import Docker
+
 try:
     from unittest import mock
 except ImportError:
     import mock
-
-from docker.manager import Docker
 
 
 class DockerBasicInteractionTests(unittest.TestCase):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -63,3 +63,14 @@ class DockerBasicInteractionTests(unittest.TestCase):
 
         mock_start.assert_called_once_with()
         mock_stop.assert_called_once_with()
+
+    @mock.patch('docker.manager.Docker.stop')
+    @mock.patch('docker.manager.Docker.start')
+    def test_wrap(self, mock_start, mock_stop):
+        @Docker.wrap()
+        def wrapped(docker):
+            self.assertIsInstance(docker, Docker)
+
+        wrapped()
+        mock_start.assert_called_once_with()
+        mock_stop.assert_called_once_with()

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,11 @@ envlist = py34,py27,docs
 skipsdist = True
 
 [testenv]
-deps = -r{toxinidir}/requirements_test.txt
 setenv = PYTHONPATH = {toxinidir}:{toxinidir}
 commands = coverage run -p --source=docker -m py.test -v tests
+deps =
+    -r{toxinidir}/requirements_test.txt
+    py27: mock
 
 [testenv:docs]
 basepython=python3.4


### PR DESCRIPTION
- Adds `start()` and `stop()` and calls them in `__enter__` and `__exit__`
- Adds `@Docker.wrap()` decorater which wraps the function in a `with Docker as docker:` statement and adds `docker` to the wrapped function's kwargs.
- Adds `DockerUnavailableError` which is thrown if the execute command in `start()` fails.
