### PR TITLE
Fix reading error issue

### DIFF
--- a/docker/manager.py
+++ b/docker/manager.py
@@ -51,7 +51,10 @@ class Docker(object):
 
     def read_file(self, path):
         path = self._get_working_directory(path)
-        return self.run('cat {0}'.format(path)).out
+        result = self.run('cat {0}'.format(path))
+        if result.succeeded:
+            return result.out
+        return None
 
     def create_file(self, path, content):
         path = self._get_working_directory(path)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -52,6 +52,10 @@ class DockerBasicInteractionTests(unittest.TestCase):
 
             self.assertEqual(docker.read_file(file_name), file_content)
 
+    def test_read_file_that_dont_exist(self):
+        with Docker() as docker:
+            self.assertIsNone(docker.read_file('no-file.txt'))
+
     def test__get_working_directory(self):
         self.assertEqual(Docker._get_working_directory('directory'), '~/directory')
         self.assertEqual(Docker._get_working_directory('/absolute/path'), '/absolute/path')


### PR DESCRIPTION
Makes read_file return None if the read command fails
