### PR TITLE
Fix tests and bugs that the tests uncovered

### DIFF
--- a/docker/manager.py
+++ b/docker/manager.py
@@ -36,10 +36,11 @@ class ProcessResult(object):
 
 
 class Docker(object):
-    def __init__(self, image='ubuntu', timeout=3600):
+    def __init__(self, image='ubuntu', timeout=3600, combine_outputs=False):
         self.container_name = 'dyn-{0}'.format(int(datetime.datetime.now().strftime('%s')) * 1000)
         self.timeout = timeout
         self.image = image
+        self.combine_outputs = combine_outputs
 
     def __enter__(self):
         return self.start()
@@ -49,9 +50,12 @@ class Docker(object):
 
     def run(self, cmd, working_directory=''):
         working_directory = self._get_working_directory(working_directory)
+        command_string = 'cd {working_directory} && {command}'
+        if self.combine_outputs:
+            command_string += ' 2>&1'
         return _execute('docker exec -i {container} bash -c "{command}"'.format(
             container=self.container_name,
-            command='cd {0} && {1}'.format(working_directory, cmd)
+            command=command_string.format(working_directory=working_directory, command=cmd)
         ))
 
     def read_file(self, path):

--- a/docker/manager.py
+++ b/docker/manager.py
@@ -151,6 +151,6 @@ class Docker(object):
 
     @staticmethod
     def _get_working_directory(working_directory):
-        if not working_directory.startswith('/'):
-            working_directory = '~/{}'.format(working_directory)
-        return working_directory
+        if working_directory.startswith('/') or working_directory.startswith('~/'):
+            return working_directory
+        return '~/{}'.format(working_directory)

--- a/docker/manager.py
+++ b/docker/manager.py
@@ -26,14 +26,23 @@ def _execute(cmd):
     result.out = stdout.decode('utf-8').strip() if stdout else ''
     result.err = stderr.decode('utf-8').strip() if stderr else ''
     result.return_code = process.returncode
-    result.succeeded = result.return_code == 0
     logger.debug('Finished running of: {0}'.format(result.__dict__))
     return result
 
 
 class ProcessResult(object):
+    return_code = None
+    out = ''
+    err = ''
+
     def __init__(self, command):
         self.command = command
+
+    @property
+    def succeeded(self):
+        if self.return_code is None:
+            return None
+        return self.return_code == 0
 
 
 class Docker(object):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -18,6 +18,7 @@ class DockerManagerTests(unittest.TestCase):
     def test__get_working_directory(self):
         self.assertEqual(Docker._get_working_directory('directory'), '~/directory')
         self.assertEqual(Docker._get_working_directory('/absolute/path'), '/absolute/path')
+        self.assertEqual(Docker._get_working_directory('~/home/path'), '~/home/path')
 
     @mock.patch('docker.manager.Docker.stop')
     @mock.patch('docker.manager.Docker.start')

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -79,3 +79,11 @@ class DockerBasicInteractionTests(unittest.TestCase):
         wrapped()
         mock_start.assert_called_once_with()
         mock_stop.assert_called_once_with()
+
+    def test_combine_output(self):
+        docker = Docker(combine_outputs=True)
+        docker.start()
+        result = docker.run('ls does-not-exist')
+        self.assertEqual(result.err, '')
+        self.assertEqual(result.out, 'ls: cannot access does-not-exist: No such file or directory')
+        docker.stop()


### PR DESCRIPTION
- Remove with statements from tests  
  with-statements catch exceptions and assertions raises exceptions which 
  means that assertion checks within with statements will never make a test 
  fail.  
- Fix return code in docker.run, fixes #4  
  docker exec does not always return the correct return code, thus a
  workaround is necessary to get the return code of the command ran within
  the container instead of the return code of docker exec. 
-  Fix issue in get_working_directory with ~/ prefix 
- Add support for combining output
- Change ProcessResult.succeeded from attribute to property, fixes #7
