### PR TITLE
Replace create_file with write_file

### DIFF
--- a/docker/manager.py
+++ b/docker/manager.py
@@ -122,19 +122,23 @@ class Docker(object):
             return result.out
         return None
 
-    def create_file(self, path, content):
+    def write_file(self, path, content, append=False):
         """
-        Create file on the given path with the given content
+        Write the given content to path.
+        Overwrites the file if append is set to False.
 
         :param path: The path to the file.
         :type path: str
         :param content: The content of the file.
         :type content: str
+        :param append: Set to False to overwrite file, defaults to False.
+        :type append: bool
         :return: A object with the result of the create command.
         :rtype: ProcessResult
         """
         path = self._get_working_directory(path)
-        return self.run('echo "{0}" >> {1}'.format(content, path))
+        modifier = '>>' if append else '>'
+        return self.run('echo "{0}" {1} {2}'.format(content, modifier, path))
 
     def file_exist(self, path):
         """

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -108,12 +108,12 @@ class DockerInteractionTests(unittest.TestCase):
     def tearDown(self):
         self.docker.stop()
 
-    def test_create_files(self):
+    def test_list_files(self):
         self.docker.run('touch file1')
         self.docker.run('touch file2')
         self.assertEqual(self.docker.list_files(''), ['file1', 'file2'])
 
-    def test_create_directories(self):
+    def test_list_directories(self):
         self.docker.run('mkdir dir1')
         self.docker.run('mkdir dir1/test')
         self.docker.run('mkdir dir2')
@@ -128,14 +128,6 @@ class DockerInteractionTests(unittest.TestCase):
         self.docker.run('touch builds/readme.txt')
 
         self.assertEqual(self.docker.list_files('builds'), ['readme.txt'])
-
-    def test_create_file_with_content(self):
-        file_name = 'readme.txt'
-        file_content = 'this is a test file'
-
-        self.assertFalse(self.docker.file_exist(file_name))
-        self.docker.create_file(file_name, file_content)
-        self.assertTrue(self.docker.file_exist(file_name))
 
     def test_read_file_with_content(self):
         file_name = 'readme.txt'
@@ -164,3 +156,23 @@ class DockerInteractionTests(unittest.TestCase):
 
     def test_privilege(self):
         Docker(privilege=True).start()
+
+    def test_write_file_append(self):
+        path = 'readme.txt'
+        old_content = 'hi'
+        content = 'this is a readme'
+        self.docker.run('echo "{0}" > {1}'.format(old_content, path))
+
+        self.docker.write_file(path, content, append=True)
+        written_content = self.docker.read_file(path)
+        self.assertEqual(written_content, '{0}\n{1}'.format(old_content, content))
+
+    def test_write_file_no_append(self):
+        path = 'readme.txt'
+        old_content = 'hi'
+        content = 'this is a readme'
+        self.docker.run('echo "{0}" > {1}'.format(old_content, path))
+
+        self.docker.write_file(path, content, append=False)
+        written_content = self.docker.read_file(path)
+        self.assertEqual(written_content, content)


### PR DESCRIPTION
`write_file` takes an extra argument, `append`, which decides if any possible old content should stay or get overwritten. 
