### PR TITLE
Add exceptions to file handling functions

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -6,10 +6,6 @@ class DockerWrapperBaseError(Exception):
     pass
 
 
-class DockerUnknownFileError(DockerWrapperBaseError):
-    pass
-
-
 class DockerUnavailableError(DockerWrapperBaseError):
     def __init__(self, message=None):
         super(DockerUnavailableError, self).__init__(message or 'Docker is not available')

--- a/docker/errors.py
+++ b/docker/errors.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
+FILE_NOT_FOUND_PREDICATE = 'No such file or directory'
+
+
 class DockerWrapperBaseError(Exception):
+    pass
+
+
+class DockerUnknownFileError(DockerWrapperBaseError):
     pass
 
 

--- a/docker/errors.py
+++ b/docker/errors.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
+class DockerWrapperBaseError(Exception):
+    pass
 
 
-class DockerUnavailableError(Exception):
-
+class DockerUnavailableError(DockerWrapperBaseError):
     def __init__(self, message=None):
         super(DockerUnavailableError, self).__init__(message or 'Docker is not available')
+
+
+class DockerFileNotFoundError(DockerWrapperBaseError):
+    def __init__(self, path):
+        message = 'Could not find the file or directory at path {0}'.format(path)
+        super(DockerFileNotFoundError, self).__init__(message)

--- a/docker/manager.py
+++ b/docker/manager.py
@@ -116,7 +116,7 @@ class Docker(object):
         :return: The content of the file
         :rtype: str
         :raises DockerFileNotFoundError: If given an invalid path
-        :raises DockerUnknownFileError: For other errors
+        :raises DockerWrapperBaseError: For other errors
         """
         path = self._get_working_directory(path)
         result = self.run('cat {0}'.format(path))
@@ -125,7 +125,7 @@ class Docker(object):
             if errors.FILE_NOT_FOUND_PREDICATE in result.err:
                 raise errors.DockerFileNotFoundError(path)
 
-            raise errors.DockerUnknownFileError(result.err)
+            raise errors.DockerWrapperBaseError(result.err)
 
         return result.out
 
@@ -178,7 +178,7 @@ class Docker(object):
         :return: An list of file names
         :rtype: list
         :raises DockerFileNotFoundError: If given an invalid path
-        :raises DockerUnknownFileError: For other errors
+        :raises DockerWrapperBaseError: For other errors
         """
 
         files = []
@@ -189,7 +189,7 @@ class Docker(object):
             if errors.FILE_NOT_FOUND_PREDICATE in result.err:
                 raise errors.DockerFileNotFoundError(path)
 
-            raise errors.DockerUnknownFileError(result.err)
+            raise errors.DockerWrapperBaseError(result.err)
 
         for file_path in result.out.split(', '):
             full_path = os.path.join(path, file_path)
@@ -207,7 +207,7 @@ class Docker(object):
         :return: An list of directory names
         :rtype: list
         :raises DockerFileNotFoundError: If given an invalid path
-        :raises DockerUnknownFileError: For other errors
+        :raises DockerWrapperBaseError: For other errors
         """
 
         files = []
@@ -218,7 +218,7 @@ class Docker(object):
             if errors.FILE_NOT_FOUND_PREDICATE in result.err:
                 raise errors.DockerFileNotFoundError(path)
 
-            raise errors.DockerUnknownFileError(result.err)
+            raise errors.DockerWrapperBaseError(result.err)
 
         for file_path in result.out.split(', '):
             if self.directory_exist(os.path.join(path, file_path)):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -84,61 +84,66 @@ class DockerManagerTests(unittest.TestCase):
 
     @mock.patch('docker.manager.execute')
     def test_single_port_mappping(self, mock_run):
-        with Docker(ports_mapping=["4080:4080"]) as docker:
-            mock_run.assert_called_once_with(
-                'docker run -d -p 4080:4080 --name {0} {1} /bin/sleep {2}'.format(
-                    docker.container_name,
-                    docker.image,
-                    docker.timeout
-                ))
+        docker = Docker(ports_mapping=['4080:4080'])
+        docker.start()
+        mock_run.assert_called_once_with(
+            'docker run -d -p 4080:4080 --name {0} {1} /bin/sleep {2}'.format(
+                docker.container_name,
+                docker.image,
+                docker.timeout
+            ))
 
     @mock.patch('docker.manager.execute')
     def test_multiple_port_mapppings(self, mock_run):
         ports = ["4080:4080", "8080:8080", "4443:4443"]
-        with Docker(ports_mapping=ports) as docker:
-            mock_run.assert_called_once_with(
-                'docker run -d {0} --name {1} {2} /bin/sleep {3}'.format(
-                    ' '.join(["-p {0}".format(port_mapping) for port_mapping in ports]),
-                    docker.container_name,
-                    docker.image,
-                    docker.timeout
-                ))
+        docker = Docker(ports_mapping=ports)
+        docker.start()
+        mock_run.assert_called_once_with(
+            'docker run -d {0} --name {1} {2} /bin/sleep {3}'.format(
+                ' '.join(["-p {0}".format(port_mapping) for port_mapping in ports]),
+                docker.container_name,
+                docker.image,
+                docker.timeout
+            ))
 
     @mock.patch('docker.manager.execute')
     @mock.patch('docker.manager.Docker.run', return_value=unknown_error_result)
     def test_read_file_unknown_error(self, mock_run, mock_execute):
-        with Docker() as docker:
-            path = 'test-file'
-            self.assertRaisesRegexp(
-                DockerWrapperBaseError,
-                unknown_error_result.err,
-                docker.read_file,
-                path
-            )
+        docker = Docker()
+        docker.start()
+        path = 'test-file'
+        self.assertRaisesRegexp(
+            DockerWrapperBaseError,
+            unknown_error_result.err,
+            docker.read_file,
+            path
+        )
 
     @mock.patch('docker.manager.execute')
     @mock.patch('docker.manager.Docker.run', return_value=unknown_error_result)
     def test_list_files_unknown_error(self, mock_run, mock_execute):
-        with Docker() as docker:
-            path = 'path'
-            self.assertRaisesRegexp(
-                DockerWrapperBaseError,
-                unknown_error_result.err,
-                docker.list_files,
-                path
-            )
+        docker = Docker()
+        docker.start()
+        path = 'path'
+        self.assertRaisesRegexp(
+            DockerWrapperBaseError,
+            unknown_error_result.err,
+            docker.list_files,
+            path
+        )
 
     @mock.patch('docker.manager.execute')
     @mock.patch('docker.manager.Docker.run', return_value=unknown_error_result)
     def test_list_directories_unknown_error(self, mock_run, mock_execute):
-        with Docker() as docker:
-            path = 'path'
-            self.assertRaisesRegexp(
-                DockerWrapperBaseError,
-                unknown_error_result.err,
-                docker.list_directories,
-                path
-            )
+        docker = Docker()
+        docker.start()
+        path = 'path'
+        self.assertRaisesRegexp(
+            DockerWrapperBaseError,
+            unknown_error_result.err,
+            docker.list_directories,
+            path
+        )
 
 
 class DockerInteractionTests(unittest.TestCase):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,7 +3,7 @@ from random import randint
 
 import six
 
-from docker.errors import DockerFileNotFoundError, DockerUnknownFileError
+from docker.errors import DockerFileNotFoundError, DockerWrapperBaseError
 from docker.helpers import ProcessResult
 from docker.manager import Docker
 
@@ -106,11 +106,11 @@ class DockerManagerTests(unittest.TestCase):
 
     @mock.patch('docker.manager.execute')
     @mock.patch('docker.manager.Docker.run', return_value=unknown_error_result)
-    def test_read_file_unknown_error(self, run_mock, execute_mock):
+    def test_read_file_unknown_error(self, mock_run, mock_execute):
         with Docker() as docker:
             path = 'test-file'
             self.assertRaisesRegexp(
-                DockerUnknownFileError,
+                DockerWrapperBaseError,
                 unknown_error_result.err,
                 docker.read_file,
                 path
@@ -118,11 +118,11 @@ class DockerManagerTests(unittest.TestCase):
 
     @mock.patch('docker.manager.execute')
     @mock.patch('docker.manager.Docker.run', return_value=unknown_error_result)
-    def test_list_files_unknown_error(self, run_mock, execute_mock):
+    def test_list_files_unknown_error(self, mock_run, mock_execute):
         with Docker() as docker:
             path = 'path'
             self.assertRaisesRegexp(
-                DockerUnknownFileError,
+                DockerWrapperBaseError,
                 unknown_error_result.err,
                 docker.list_files,
                 path
@@ -130,11 +130,11 @@ class DockerManagerTests(unittest.TestCase):
 
     @mock.patch('docker.manager.execute')
     @mock.patch('docker.manager.Docker.run', return_value=unknown_error_result)
-    def test_list_directories_unknown_error(self, run_mock, execute_mock):
+    def test_list_directories_unknown_error(self, mock_run, mock_execute):
         with Docker() as docker:
             path = 'path'
             self.assertRaisesRegexp(
-                DockerUnknownFileError,
+                DockerWrapperBaseError,
                 unknown_error_result.err,
                 docker.list_directories,
                 path

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,6 +3,7 @@ from random import randint
 
 import six
 
+from docker.errors import DockerFileNotFoundError
 from docker.manager import Docker
 
 try:
@@ -113,6 +114,15 @@ class DockerInteractionTests(unittest.TestCase):
         self.docker.run('touch file2')
         self.assertEqual(self.docker.list_files(''), ['file1', 'file2'])
 
+    def test_list_files_bad_path(self):
+        path = '/bad/path'
+        self.assertRaisesRegexp(
+            DockerFileNotFoundError,
+            'Could not find the file or directory at path {0}'.format(path),
+            self.docker.list_files,
+            path
+        )
+
     def test_list_directories(self):
         self.docker.run('mkdir dir1')
         self.docker.run('mkdir dir1/test')
@@ -121,6 +131,15 @@ class DockerInteractionTests(unittest.TestCase):
         self.assertEqual(
             self.docker.list_directories('', include_trailing_slash=False),
             ['dir1', 'dir2', 'dir3']
+        )
+
+    def test_list_directories_bad_path(self):
+        path = '/bad/path'
+        self.assertRaisesRegexp(
+            DockerFileNotFoundError,
+            'Could not find the file or directory at path {0}'.format(path),
+            self.docker.list_directories,
+            path
         )
 
     def test_create_and_list_files_in_sub_directory(self):
@@ -137,7 +156,13 @@ class DockerInteractionTests(unittest.TestCase):
         self.assertEqual(self.docker.read_file(file_name), file_content)
 
     def test_read_file_that_dont_exist(self):
-        self.assertIsNone(self.docker.read_file('no-file.txt'))
+        path = '/bad/path'
+        self.assertRaisesRegexp(
+            DockerFileNotFoundError,
+            'Could not find the file or directory at path {0}'.format(path),
+            self.docker.read_file,
+            path
+        )
 
     def test_directory_exist(self):
         self.assertTrue(self.docker.directory_exist('~/'))


### PR DESCRIPTION
This makes read_file, list_directories and list_files raise a
`DockerFileNotFoundError` if given a bad path.
