### PR TITLE
Use cat instead of echo for write_file

### DIFF
--- a/docker/helpers.py
+++ b/docker/helpers.py
@@ -20,19 +20,20 @@ class ProcessResult(object):
         return self.return_code == 0
 
 
-def execute(cmd):
+def execute(cmd, stdin=''):
     result = ProcessResult(command=cmd)
 
     logger.debug('Running command: "{0}"'.format(cmd))
     process = subprocess.Popen(
         cmd,
         shell=True,
+        stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         close_fds=True
     )
 
-    (stdout, stderr) = process.communicate()
+    (stdout, stderr) = process.communicate(str.encode(stdin))
     result.out = stdout.decode('utf-8').strip() if stdout else ''
     result.err = stderr.decode('utf-8').strip() if stderr else ''
     result.return_code = process.returncode

--- a/docker/manager.py
+++ b/docker/manager.py
@@ -61,7 +61,7 @@ class Docker(object):
         if exc_value:
             raise exc_value
 
-    def run(self, command, working_directory=''):
+    def run(self, command, working_directory='', stdin=''):
         """
         Runs the command with docker exec in the given working directory.
 
@@ -72,6 +72,7 @@ class Docker(object):
                                   will be evaluated with ``_get_working_directory``, thus relative
                                   paths will become absolute paths.
         :type working_directory: str
+        :type stdin: str
         :return: A ProcessResult object containing information on the result of the command.
         :rtype: ProcessResult
         """
@@ -95,7 +96,8 @@ class Docker(object):
                     command=command,
                     envs=env_string
                 )
-            )
+            ),
+            stdin
         )
 
         return_code_match = re.search(r'(?:\\n)?--return-(\d+)--$', result.out)
@@ -144,7 +146,7 @@ class Docker(object):
         """
         path = self._get_working_directory(path)
         modifier = '>>' if append else '>'
-        return self.run('echo "{0}" {1} {2}'.format(content, modifier, path))
+        return self.run('cat {0} {1}'.format(modifier, path), stdin=content)
 
     def file_exist(self, path):
         """


### PR DESCRIPTION
Passes the file content in through stdin. With `echo`, stuff like `write_file('path', '$(ls /)')` will evaluate the actual command. Using `cat` also lets you have double quotes in `content` without escaping it first.
