### PR TITLE
Remove return code workaround and fix EOF newline behavior

### DIFF
--- a/docker/helpers.py
+++ b/docker/helpers.py
@@ -34,8 +34,8 @@ def execute(cmd, stdin=''):
     )
 
     (stdout, stderr) = process.communicate(str.encode(stdin))
-    result.out = stdout.decode('utf-8').strip() if stdout else ''
-    result.err = stderr.decode('utf-8').strip() if stderr else ''
+    result.out = stdout.decode('utf-8') if stdout else ''
+    result.err = stderr.decode('utf-8') if stderr else ''
     result.return_code = process.returncode
     logger.debug('Finished running of: {0}'.format(result.__dict__))
     return result

--- a/docker/manager.py
+++ b/docker/manager.py
@@ -187,7 +187,7 @@ class Docker(object):
 
             raise errors.DockerWrapperBaseError(result.err)
 
-        return result.out.split('\n')
+        return result.out.strip().split('\n')
 
     def list_directories(self, path, include_trailing_slash=True):
         """
@@ -211,7 +211,7 @@ class Docker(object):
 
             raise errors.DockerWrapperBaseError(result.err)
 
-        for file_path in result.out.split(', '):
+        for file_path in result.out.strip().split(', '):
             if include_trailing_slash:
                 files.append(file_path)
             else:

--- a/docker/manager.py
+++ b/docker/manager.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import uuid
 from collections import OrderedDict
 from time import sleep
@@ -88,7 +87,7 @@ class Docker(object):
         ])
 
         result = execute(
-            'docker exec -i {container} bash -c \'{command} ;  echo "--return-$?--"\''.format(
+            'docker exec -i {container} bash -c \'{command}\''.format(
                 envs=env_string,
                 container=self.container_name,
                 command=command_string.format(
@@ -100,12 +99,6 @@ class Docker(object):
             stdin
         )
 
-        return_code_match = re.search(r'(?:\\n)?--return-(\d+)--$', result.out)
-        if return_code_match:
-            result.return_code = int(return_code_match.group(1))
-            result.out = result.out.replace(return_code_match.group(0), '')
-            if result.out.endswith('\n'):
-                result.out = result.out[:len(result.out) - 1]
         return result
 
     def read_file(self, path):


### PR DESCRIPTION
Since https://github.com/docker/docker/commit/00c2a8f323548b7d0aa54cfd10a594dd93ddbed0 fixed `docker exec`, making it return the correct exit code the current workaround is no longer needed.

This also makes sure end of file newlines aren't eaten, which in turn results in a breaking change as `read_file()` would previously ignore the last newline.
