### PR TITLE
Remove color=never

### DIFF
--- a/docker/manager.py
+++ b/docker/manager.py
@@ -185,7 +185,7 @@ class Docker(object):
 
         # `grep -v /$` matches everything that doesn't end with a
         # trailing slash, i.e. only files since `ls -p` is used:
-        result = self.run('ls -p | grep --color=never -v /$', path)
+        result = self.run('ls -p | grep -v /$', path)
 
         if not result.succeeded:
             if errors.FILE_NOT_FOUND_PREDICATE in result.err:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -82,9 +82,9 @@ class DockerManagerTests(unittest.TestCase):
     @mock.patch('re.search', lambda *x: None)
     def test_env_variables(self, mock_run):
         docker = Docker(env_variables={'CI': 1, 'FRIGG': 1})
-        docker.run('ls')
+        docker.run('ls', login=True)
         mock_run.assert_called_once_with(
-            'docker exec -i -t {} bash --login -c \'cd ~/ && CI=1 FRIGG=1 ls\''.format(
+            'docker exec -i {0} bash --login -c \'cd ~/ && CI=1 FRIGG=1 ls\''.format(
                 docker.container_name
             ),
             ''


### PR DESCRIPTION
Not needed, and all versions of bash don't have the option.
Also fixes a failing test.
